### PR TITLE
 update the npm dependencies to use @hapi/*

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Hoek = require('hoek');
-const Joi = require('joi');
-const Boom = require('boom');
+const Hoek = require('@hapi/hoek');
+const Joi = require('@hapi/joi');
+const Boom = require('@hapi/boom');
 
 const register = (server, options) => {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,474 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@hapi/accept": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
+      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/address": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
+      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+    },
+    "@hapi/ammo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
+      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/b64": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
+      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/boom": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
+      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        }
+      }
+    },
+    "@hapi/bounce": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.1.tgz",
+      "integrity": "sha512-/ecFQTRBom2MEbjMHvKKE6FZ/e1gYK72CeUIFzz++dKK1kYJ0KbRJ72mXroWoTT2hIv+8H0ua/eOkO0+hRdHcw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/call": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
+      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/catbox": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
+      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
+      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/content": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
+      "integrity": "sha512-hv2Czsl49hnWDEfRZOFow/BmYbKyfEknmk3k83gOp6moFn5ceHB4xVcna8OwsGfy8dxO81lhpPy+JgQEaU4SWw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
+      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ==",
+      "dev": true
+    },
+    "@hapi/hapi": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
+      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/accept": "3.x.x",
+        "@hapi/ammo": "3.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/call": "5.x.x",
+        "@hapi/catbox": "10.x.x",
+        "@hapi/catbox-memory": "4.x.x",
+        "@hapi/heavy": "6.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/mimos": "4.x.x",
+        "@hapi/podium": "3.x.x",
+        "@hapi/shot": "4.x.x",
+        "@hapi/somever": "2.x.x",
+        "@hapi/statehood": "6.x.x",
+        "@hapi/subtext": "6.x.x",
+        "@hapi/teamwork": "3.x.x",
+        "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/heavy": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
+      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/hoek": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.0.2.tgz",
+      "integrity": "sha512-O6o6mrV4P65vVccxymuruucb+GhP2zl9NLCG8OdoFRS8BEGw3vwpPp20wpAtpbQQxz1CEUtmxJGgWhjq1XA3qw=="
+    },
+    "@hapi/iron": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
+      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
+      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/marker": "1.x.x",
+        "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        }
+      }
+    },
+    "@hapi/marker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
+      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
+    },
+    "@hapi/mimos": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
+      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "mime-db": "1.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/nigel": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
+      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/vise": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/pez": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
+      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "dev": true,
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/nigel": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/podium": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
+      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/shot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
+      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x",
+        "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/somever": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
+      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/statehood": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
+      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "6.x.x",
+        "@hapi/iron": "5.x.x",
+        "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/subtext": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
+      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/content": "4.x.x",
+        "@hapi/file": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/pez": "4.x.x",
+        "@hapi/wreck": "15.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
+      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/vise": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
+      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
+    "@hapi/wreck": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
+      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
+      }
+    },
     "acorn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
@@ -94,6 +562,7 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
       "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+      "dev": true,
       "requires": {
         "hoek": "6.x.x"
       }
@@ -533,307 +1002,6 @@
         }
       }
     },
-    "hapi": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.8.1.tgz",
-      "integrity": "sha512-0zfkl8YtJPfkOG+1KwFnZOk7/mmO2LrExJLWIJwzmwsyxLcQXNrnfwgk205xxxg9tnOO6OdCTQLkPG8Wn+McXw==",
-      "dev": true,
-      "requires": {
-        "accept": "3.x.x",
-        "ammo": "3.x.x",
-        "boom": "7.x.x",
-        "bounce": "1.x.x",
-        "call": "5.x.x",
-        "catbox": "10.x.x",
-        "catbox-memory": "3.x.x",
-        "heavy": "6.x.x",
-        "hoek": "6.x.x",
-        "joi": "14.x.x",
-        "mimos": "4.x.x",
-        "podium": "3.x.x",
-        "shot": "4.x.x",
-        "somever": "2.x.x",
-        "statehood": "6.x.x",
-        "subtext": "6.x.x",
-        "teamwork": "3.x.x",
-        "topo": "3.x.x"
-      },
-      "dependencies": {
-        "accept": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-          "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "ammo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.3.tgz",
-          "integrity": "sha512-vo76VJ44MkUBZL/BzpGXaKzMfroF4ZR6+haRuw9p+eSWfoNaH2AxVc8xmiEPC08jhzJSeM6w7/iMUGet8b4oBQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "b64": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/b64/-/b64-4.1.2.tgz",
-          "integrity": "sha512-+GUspBxlH3CJaxMUGUE1EBoWM6RKgWiYwUDal0qdf8m3ArnXNN1KzKVo5HOnE/FSq4HHyWf3TlHLsZI8PKQgrQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "big-time": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.1.tgz",
-          "integrity": "sha512-qtwYYoocwpiAxTXC5sIpB6nH5j6ckt+n/jhD7J5OEiFHnUZEFn0Xk8STUaE5s10LdazN/87bTDMe+fSihaW7Kg==",
-          "dev": true
-        },
-        "boom": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
-          "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "bounce": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.2.tgz",
-          "integrity": "sha512-1LPcXg3fkGVhjdA/P3DcR5cDktKEYtDpruJv9Nhmy36RoYaoxZfC82Zr2JmS3vysDJKqMtP0qJw3/P6iisTASg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "call": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/call/-/call-5.0.3.tgz",
-          "integrity": "sha512-eX16KHiAYXugbFu6VifstSdwH6aMuWWb4s0qvpq1nR1b+Sf+u68jjttg8ixDBEldPqBi30bDU35OJQWKeTLKxg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "catbox": {
-          "version": "10.0.5",
-          "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.5.tgz",
-          "integrity": "sha512-5SpI/tEP3SiLE1qkkV+/hdVW48sHVBEbzPX4jBiwl6hsZh/gkl4bqfGLkvh7mjpMK5evJ0Rm/6NRlhF/Jsy9ow==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "catbox-memory": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.4.tgz",
-          "integrity": "sha512-1tDnll066au0HXBSDHS/YQ34MQ2omBsmnA9g/jseyq/M3m7UPrajVtPDZK/rXgikSC1dfjo9Pa+kQ1qcyG2d3g==",
-          "dev": true,
-          "requires": {
-            "big-time": "2.x.x",
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "content": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/content/-/content-4.0.6.tgz",
-          "integrity": "sha512-lR9ND3dXiMdmsE84K6l02rMdgiBVmtYWu1Vr/gfSGHcIcznBj2QxmSdUgDuNFOA+G9yrb1IIWkZ7aKtB6hDGyA==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "cryptiles": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x"
-          }
-        },
-        "heavy": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.2.tgz",
-          "integrity": "sha512-cJp884bqhiebNcEHydW0g6V1MUGYOXRPw9c7MFiHQnuGxtbWuSZpsbojwb2kxb3AA1/Rfs8CNiV9MMOF8pFRDg==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "hoek": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.1.tgz",
-          "integrity": "sha512-3PvUwBerLNVJiIVQdpkWF9F/M0ekgb2NPJWOhsE28RXSQPsY42YSnaJ8d1kZjcAz58TZ/Fk9Tw64xJsENFlJNw==",
-          "dev": true
-        },
-        "iron": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
-          "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
-          "dev": true,
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "joi": {
-          "version": "14.0.4",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-14.0.4.tgz",
-          "integrity": "sha512-KUXRcinDUMMbtlOk7YLGHQvG73dLyf8bmgE+6sBTkdJbZpeGVGAlPXEHLiQBV7KinD/VLD5OA0EUgoTTfbRAJQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "isemail": "3.x.x",
-            "topo": "3.x.x"
-          }
-        },
-        "mime-db": {
-          "version": "1.37.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-          "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-          "dev": true
-        },
-        "mimos": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.2.tgz",
-          "integrity": "sha512-5XBsDqBqzSN88XPPH/TFpOalWOjHJM5Z2d3AMx/30iq+qXvYKd/8MPhqBwZDOLtoaIWInR3nLzMQcxfGK9djXA==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "mime-db": "1.x.x"
-          }
-        },
-        "nigel": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.4.tgz",
-          "integrity": "sha512-3SZCCS/duVDGxFpTROHEieC+itDo4UqL9JNUyQJv3rljudQbK6aqus5B4470OxhESPJLN93Qqxg16rH7DUjbfQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "vise": "3.x.x"
-          }
-        },
-        "pez": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.5.tgz",
-          "integrity": "sha512-HvL8uiFIlkXbx/qw4B8jKDCWzo7Pnnd65Uvanf9OOCtb20MRcb9gtTVBf9NCnhETif1/nzbDHIjAWC/sUp7LIQ==",
-          "dev": true,
-          "requires": {
-            "b64": "4.x.x",
-            "boom": "7.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "nigel": "3.x.x"
-          }
-        },
-        "podium": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.5.tgz",
-          "integrity": "sha512-+fAPmAj3d5fWKx5oSjQKeBIcl46/qZnGLhzyi/dJ/HzNiOpuxyX/Y4091LiVxZQ4ALdf/LCS7siV6ai5nNLlOg==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "shot": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.7.tgz",
-          "integrity": "sha512-RKaKAGKxJ11EjJl0cf2fYVSsd4KB5Cncb9J0v7w+0iIaXpxNqFWTYNDNhBX7f0XSyDrjOH9a4OWZ9Gp/ZML+ew==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "somever": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/somever/-/somever-2.0.0.tgz",
-          "integrity": "sha512-9JaIPP+HxwYGqCDqqK3tRaTqdtQHoK6Qy3IrXhIt2q5x8fs8RcfU7BMWlFTCOgFazK8p88zIv1tHQXvAwtXMyw==",
-          "dev": true,
-          "requires": {
-            "bounce": "1.x.x",
-            "hoek": "6.x.x"
-          }
-        },
-        "statehood": {
-          "version": "6.0.8",
-          "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.8.tgz",
-          "integrity": "sha512-/uk2Iq5VXCAGmYnRTjez6gDfU8fROm1Um5WH2C9aNCdG7DAqD94dqZgeuqXrvVFnfDqxAtorUBLUtD9El/uJ6w==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "bounce": "1.x.x",
-            "cryptiles": "4.x.x",
-            "hoek": "6.x.x",
-            "iron": "5.x.x",
-            "joi": "14.x.x"
-          }
-        },
-        "subtext": {
-          "version": "6.0.11",
-          "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.11.tgz",
-          "integrity": "sha512-jap1ev33dbVTBPxpIyJ5OvD9/J4oWlx1qHQ8bBnKpiwItxXt3+7tvmNZqZeTEQVTjvkReHY1ZnP/7iltNdGnOA==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "content": "4.x.x",
-            "hoek": "6.x.x",
-            "pez": "4.x.x",
-            "wreck": "14.x.x"
-          }
-        },
-        "teamwork": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.2.tgz",
-          "integrity": "sha512-tpG01+9Qws/oGhMBiZN3BnB32gn5QeKY84AmLxxaCJw4mNeRzhEZ6jEj/vBhKerHD7Hgq9/vOZ58pyryYSn9gA==",
-          "dev": true
-        },
-        "topo": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
-          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "vise": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.1.tgz",
-          "integrity": "sha512-7BJNjsv2o83+E6AHAFSnjQF324UTgypsR/Sw/iFmLvr7RgJrEXF1xNBvb5LJfi+1FvWQXjJK4X41WMuHMeunPQ==",
-          "dev": true,
-          "requires": {
-            "hoek": "6.x.x"
-          }
-        },
-        "wreck": {
-          "version": "14.1.3",
-          "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.1.3.tgz",
-          "integrity": "sha512-hb/BUtjX3ObbwO3slCOLCenQ4EP8e+n8j6FmTne3VhEFp5XV1faSJojiyxVSvw34vgdeTG5baLTl4NmjwokLlw==",
-          "dev": true,
-          "requires": {
-            "boom": "7.x.x",
-            "hoek": "6.x.x"
-          }
-        }
-      }
-    },
     "hapi-capitalize-modules": {
       "version": "1.1.6",
       "resolved": "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
@@ -867,7 +1035,8 @@
     "hoek": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -966,6 +1135,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dev": true,
       "requires": {
         "punycode": "2.x.x"
       }
@@ -980,6 +1150,7 @@
       "version": "14.3.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
       "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "dev": true,
       "requires": {
         "hoek": "6.x.x",
         "isemail": "3.x.x",
@@ -1074,6 +1245,12 @@
       "version": "4.17.14",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
       "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mimic-fn": {
@@ -1243,7 +1420,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -1463,6 +1641,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
       "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "dev": true,
       "requires": {
         "hoek": "6.x.x"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-alive",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Health route for your Hapi.js server",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   "homepage": "https://github.com/idoshamun/hapi-alive#readme",
   "devDependencies": {
     "code": "^5.2.4",
-    "hapi": "^17.8.1",
+    "@hapi/hapi": "^18.3.1",
     "lab": "^17.3.0"
   },
   "dependencies": {
-    "boom": "^7.3.0",
-    "hoek": "^6.1.2",
-    "joi": "^14.3.1"
+    "@hapi/boom": "^7.4.2",
+    "@hapi/hoek": "^8.0.2",
+    "@hapi/joi": "^15.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Code = require('code');
 const Lab = require('lab');
 const Alive = require('../');


### PR DESCRIPTION
This is to avoid the dependencies warnings:

```
[1/4] 🔍  Resolving packages...
warning hapi-alive > boom@7.3.0: This module has moved and is now available at @hapi/boom. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > hoek@6.1.3: This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > boom > hoek@6.1.3: This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > joi@14.3.1: This module has moved and is now available at @hapi/joi. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > joi > hoek@6.1.3: This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > joi > topo@3.0.3: This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
warning hapi-alive > joi > topo > hoek@6.1.3: This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
```